### PR TITLE
Add Notion API versioning date

### DIFF
--- a/lib/notion.dart
+++ b/lib/notion.dart
@@ -25,11 +25,17 @@ class NotionClient {
 
   /// Main Notion client constructor.
   ///
-  /// Require the [token] to authenticate the requests, and the API [version] where to make the calls, which is the latests by default (v1).
+  /// Require the [token] to authenticate the requests. Also can receive the API [version] where to make the calls, which is the latests by default (v1); and the [dateVersion] which is by default "2021-05-13" (the latest at 04/07/2021).
   ///
   /// This class is used as the main entry point for all clients. From the instances of this class any other client can be used.
-  NotionClient({required String token, String version: latestVersion})
-      : this.pages = NotionPagesClient(token: token, version: version),
-        this.databases = NotionDatabasesClient(token: token, version: version),
-        this.blocks = NotionBlockClient(token: token, version: version);
+  NotionClient(
+      {required String token,
+      String version: latestVersion,
+      String dateVersion: latestDateVersion})
+      : this.pages = NotionPagesClient(
+            token: token, version: version, dateVersion: dateVersion),
+        this.databases = NotionDatabasesClient(
+            token: token, version: version, dateVersion: dateVersion),
+        this.blocks = NotionBlockClient(
+            token: token, version: version, dateVersion: dateVersion);
 }

--- a/lib/notion_blocks.dart
+++ b/lib/notion_blocks.dart
@@ -17,12 +17,19 @@ class NotionBlockClient {
   /// The path of the requests group.
   String _path = 'blocks';
 
+  /// Notion versioning. For reference, see: [Notion versioning](https://developers.notion.com/reference/versioning)
+  String _dateVersion;
+
   /// Main Notion block client constructor.
   ///
   /// Require the [token] to authenticate the requests, and the API [version] where to make the calls, which is the latests by default (v1).
-  NotionBlockClient({required String token, String version: latestVersion})
+  NotionBlockClient(
+      {required String token,
+      String version: latestVersion,
+      String dateVersion: latestDateVersion})
       : this._token = token,
-        this._v = version;
+        this._v = version,
+        this._dateVersion = dateVersion;
 
   /// Retrieve the block children from block with [id].
   ///
@@ -44,6 +51,7 @@ class NotionBlockClient {
     http.Response response = await http
         .get(Uri.https(host, '/$_v/$_path/$id/children', query), headers: {
       'Authorization': 'Bearer $_token',
+      'Notion-Version': _dateVersion,
     });
 
     return NotionResponse.fromResponse(response);
@@ -60,6 +68,7 @@ class NotionBlockClient {
         headers: {
           'Authorization': 'Bearer $_token',
           'Content-Type': 'application/json; charset=UTF-8',
+          'Notion-Version': _dateVersion,
         });
 
     return NotionResponse.fromResponse(res);

--- a/lib/notion_databases.dart
+++ b/lib/notion_databases.dart
@@ -11,21 +11,26 @@ class NotionDatabasesClient {
   /// The API version.
   String _v;
 
+  /// Notion versioning. For reference, see: [Notion versioning](https://developers.notion.com/reference/versioning)
+  String _dateVersion;
+
   /// The path of the requests group.
   String _path = 'databases';
 
   /// Main Notion database client constructor.
   ///
   /// Require the [token] to authenticate the requests, and the API [version] where to make the calls, which is the latests by default (v1).
-  NotionDatabasesClient({required String token, String version: latestVersion})
+  NotionDatabasesClient({required String token, String version: latestVersion, String dateVersion: latestDateVersion})
       : this._token = token,
-        this._v = version;
+        this._v = version,
+        this._dateVersion = dateVersion;
 
   /// Retrieve the database with [id].
   Future<NotionResponse> fetch(String id) async {
     http.Response res =
         await http.get(Uri.https(host, '/$_v/$_path/$id'), headers: {
       'Authorization': 'Bearer $_token',
+      'Notion-Version': _dateVersion,
     });
 
     return NotionResponse.fromResponse(res);
@@ -47,6 +52,7 @@ class NotionDatabasesClient {
     http.Response res =
         await http.get(Uri.https(host, '/$_v/$_path', query), headers: {
       'Authorization': 'Bearer $_token',
+      'Notion-Version': _dateVersion,
     });
 
     return NotionResponse.fromResponse(res);

--- a/lib/notion_pages.dart
+++ b/lib/notion_pages.dart
@@ -14,21 +14,29 @@ class NotionPagesClient {
   /// The API version.
   String _v;
 
+  /// Notion versioning. For reference, see: [Notion versioning](https://developers.notion.com/reference/versioning)
+  String _dateVersion;
+
   /// The path of the requests group.
   String _path = 'pages';
 
   /// Main Notion page client constructor.
   ///
   /// Require the [token] to authenticate the requests, and the API [version] where to make the calls, which is the latests by default (v1).
-  NotionPagesClient({required String token, String version: latestVersion})
+  NotionPagesClient(
+      {required String token,
+      String version: latestVersion,
+      String dateVersion: latestDateVersion})
       : this._token = token,
-        this._v = version;
+        this._v = version,
+        this._dateVersion = latestDateVersion;
 
   /// Retrieve the page with [id].
   Future<NotionResponse> fetch(String id) async {
     http.Response res =
         await http.get(Uri.https(host, '/$_v/$_path/$id'), headers: {
       'Authorization': 'Bearer $_token',
+      'Notion-Version': _dateVersion,
     });
 
     return NotionResponse.fromResponse(res);
@@ -41,6 +49,7 @@ class NotionPagesClient {
         headers: {
           'Authorization': 'Bearer $_token',
           'Content-Type': 'application/json; charset=UTF-8',
+          'Notion-Version': _dateVersion,
         });
 
     return NotionResponse.fromResponse(res);

--- a/lib/statics.dart
+++ b/lib/statics.dart
@@ -5,3 +5,7 @@ const String host = "api.notion.com";
 ///
 /// **Note:** At this point there is not a stable version yet.
 const String latestVersion = 'v1';
+
+
+/// The latest version of Notion API
+const String latestDateVersion = '2021-05-13';


### PR DESCRIPTION
When I first using this package, the package did not work because Notion enforcing "Notion-Version" header requirement for all API requests on July 1st. Because of that, I add the header requirement into this package.

Sorry, I didn't do unit testing the code beforehand, I hope it will works just fine.